### PR TITLE
C functions from lua for lua will be unsafe

### DIFF
--- a/src/ffi/lua.rs
+++ b/src/ffi/lua.rs
@@ -89,17 +89,17 @@ pub type lua_Unsigned = luaconf::LUA_UNSIGNED;
 pub type lua_KContext = luaconf::LUA_KCONTEXT;
 
 // Type for C functions registered with Lua
-pub type lua_CFunction = Option<extern "C" fn(L: *mut lua_State) -> c_int>;
+pub type lua_CFunction = Option<unsafe extern "C" fn(L: *mut lua_State) -> c_int>;
 
 // Type for continuation functions
-pub type lua_KFunction = Option<extern "C" fn(L: *mut lua_State, status: c_int, ctx: lua_KContext) -> c_int>;
+pub type lua_KFunction = Option<unsafe extern "C" fn(L: *mut lua_State, status: c_int, ctx: lua_KContext) -> c_int>;
 
 // Type for functions that read/write blocks when loading/dumping Lua chunks
-pub type lua_Reader = Option<extern "C" fn(L: *mut lua_State, ud: *mut c_void, sz: *mut size_t) -> *const c_char>;
-pub type lua_Writer = Option<extern "C" fn(L: *mut lua_State, p: *const c_void, sz: size_t, ud: *mut c_void) -> c_int>;
+pub type lua_Reader = Option<unsafe extern "C" fn(L: *mut lua_State, ud: *mut c_void, sz: *mut size_t) -> *const c_char>;
+pub type lua_Writer = Option<unsafe extern "C" fn(L: *mut lua_State, p: *const c_void, sz: size_t, ud: *mut c_void) -> c_int>;
 
 // Type for memory-allocation functions
-pub type lua_Alloc = Option<extern "C" fn(ud: *mut c_void, ptr: *mut c_void, osize: size_t, nsize: size_t) -> *mut c_void>;
+pub type lua_Alloc = Option<unsafe extern "C" fn(ud: *mut c_void, ptr: *mut c_void, osize: size_t, nsize: size_t) -> *mut c_void>;
 
 extern {
   // state manipulation


### PR DESCRIPTION
Example program that won't compile before and will after:

```rust
let s = "return \"hello, world\"";
let mut state = lua::State::new();
//state.open_libs();
state.requiref("base", Some(lua::ffi::lualib::luaopen_base), false);
state.do_string(s);
println!("Returned: {:?}", state.check_string(2));
```

I really only know that this is true for `lua_CFunction`, but I'm assuming it's true for the others as well.

I can write a unit test for this if you'd like, just let me know where you'd like it.

Side note: I know that code is a bit odd, but using State::remove gives me linker errors, still working through that one.