### PR TITLE
Make ToLua require a sized type.

### DIFF
--- a/src/wrapper/convert.rs
+++ b/src/wrapper/convert.rs
@@ -90,7 +90,7 @@ impl<T: ToLua> ToLua for Option<T> {
 ///
 /// It is important that implementors of this trait ensure that `from_lua`
 /// behaves like one of the `lua_to*` functions for consistency.
-pub trait FromLua {
+pub trait FromLua: Sized {
   /// Converts the value on top of the stack of a Lua state to a value of type
   /// `Option<Self>`.
   fn from_lua(state: &mut State) -> Option<Self>;
@@ -142,4 +142,3 @@ impl FromLua for Function {
     }
   }
 }
-


### PR DESCRIPTION
Fixes these errors on nightly:

~~~
src/wrapper/convert.rs:96:3: 96:50 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/wrapper/convert.rs:96   fn from_lua(state: &mut State) -> Option<Self>;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/wrapper/convert.rs:96:3: 96:50 help: run `rustc --explain E0277` to see a detailed explanation
src/wrapper/convert.rs:96:3: 96:50 note: `Self` does not have a constant size known at compile-time
src/wrapper/convert.rs:96   fn from_lua(state: &mut State) -> Option<Self>;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/wrapper/convert.rs:96:3: 96:50 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/wrapper/convert.rs:96   fn from_lua(state: &mut State) -> Option<Self>;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/wrapper/convert.rs:96:3: 96:50 note: required by `core::option::Option`
src/wrapper/convert.rs:96   fn from_lua(state: &mut State) -> Option<Self>;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
~~~

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jcmoyer/rust-lua53/7)
<!-- Reviewable:end -->
