### PR TITLE
Use deref coercions instead of .as_str()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@
 #![crate_name = "lua"]
 #![crate_type = "lib"]
 
-#![feature(convert)]
-
 extern crate libc;
 #[macro_use]
 extern crate bitflags;

--- a/src/wrapper/convert.rs
+++ b/src/wrapper/convert.rs
@@ -41,7 +41,7 @@ impl<'a> ToLua for &'a str {
 
 impl ToLua for String {
   fn to_lua(&self, state: &mut State) {
-    state.push_string(self.as_str());
+    state.push_string(&self);
   }
 }
 


### PR DESCRIPTION
Removes dependency on the `convert` feature gate. Combined with #8, allows the library to compile on the stable channel.