### PR TITLE
Change load_buffer and load_bufferx to take &[u8]

### DIFF
--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -1201,11 +1201,10 @@ impl State {
   }
 
   /// Maps to `luaL_loadbufferx`.
-  pub fn load_bufferx(&mut self, buff: &str, sz: size_t, name: &str, mode: &str) -> ThreadStatus {
-    let buff_c_str = CString::new(buff).unwrap();
+  pub fn load_bufferx(&mut self, buff: &[u8], name: &str, mode: &str) -> ThreadStatus {
     let name_c_str = CString::new(name).unwrap();
     let mode_c_str = CString::new(mode).unwrap();
-    let result = unsafe { ffi::luaL_loadbufferx(self.L, buff_c_str.as_ptr(), sz, name_c_str.as_ptr(), mode_c_str.as_ptr()) };
+    let result = unsafe { ffi::luaL_loadbufferx(self.L, buff.as_ptr() as *const _, buff.len() as size_t, name_c_str.as_ptr(), mode_c_str.as_ptr()) };
     ThreadStatus::from_c_int(result).unwrap()
   }
 
@@ -1334,10 +1333,9 @@ impl State {
   // omitted: luaL_opt (undocumented function)
 
   /// Maps to `luaL_loadbuffer`.
-  pub fn load_buffer(&mut self, buff: &str, sz: size_t, name: &str) -> ThreadStatus {
-    let buff_c_str = CString::new(buff).unwrap();
+  pub fn load_buffer(&mut self, buff: &[u8], name: &str) -> ThreadStatus {
     let name_c_str = CString::new(name).unwrap();
-    let result = unsafe { ffi::luaL_loadbuffer(self.L, buff_c_str.as_ptr(), sz, name_c_str.as_ptr()) };
+    let result = unsafe { ffi::luaL_loadbuffer(self.L, buff.as_ptr() as *const _, buff.len() as size_t, name_c_str.as_ptr()) };
     ThreadStatus::from_c_int(result).unwrap()
   }
 


### PR DESCRIPTION
These functions can accept binary data (i.e. bytecode files), and the size can be derived from the length of the slice.