### PR TITLE
Move lua_close call to Drop impl

### DIFF
--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -279,8 +279,11 @@ impl State {
   // State manipulation
   //===========================================================================
   /// Maps to `lua_close`.
-  pub fn close(&mut self) {
-    unsafe { ffi::lua_close(self.L) }
+  pub fn close(self) {
+    // lua_close will be called in the Drop impl
+    if !self.owned {
+      panic!("cannot explicitly close non-owned Lua state")
+    }
   }
 
   /// Maps to `lua_newthread`.
@@ -1347,7 +1350,7 @@ impl State {
 impl Drop for State {
   fn drop(&mut self) {
     if self.owned {
-      self.close();
+      unsafe { ffi::lua_close(self.L) }
     }
   }
 }


### PR DESCRIPTION
It seems to me that to allow calling `lua_close()` on a `&mut State` or on a non-owning `State` is to violate memory safety, since future attempts to use the `State` will almost certainly crash.

I'm not even sure the `close` method should exist, since `drop(state)` is sufficient to close an owned state before its scope ends.