### PR TITLE
Use length-based string functions and return &strs

### DIFF
--- a/src/wrapper/convert.rs
+++ b/src/wrapper/convert.rs
@@ -98,7 +98,7 @@ pub trait FromLua: Sized {
 
 impl FromLua for String {
   fn from_lua(state: &mut State) -> Option<String> {
-    state.to_str(-1)
+    state.to_str(-1).map(ToOwned::to_owned)
   }
 }
 


### PR DESCRIPTION
There are two related sets of changes in this patch:

1. Use the length-based variants of string functions where available. This reduces allocations and allows embedding nulls in strings.
2. Return references from string functions rather than owned Strings. This reduces allocations in cases where the returned result is not actually used, and the old behavior can be gained by appending `.to_owned()` to call sites.
  * Based on the Lua source, `typename_of` and `typename_at` return `'static` strings.

I think the first point is pretty important, but the second is somewhat opinion-based. Thoughts?

Also, I should point out I here changed `to_str` to use `luaL_tolstring`, which converts more types of things to strings, and doesn't edit the stack in-place. Maybe this isn't desired.