### PR TITLE
Improve documentation and module layout

### DIFF
--- a/src/ffi/lua.rs
+++ b/src/ffi/lua.rs
@@ -29,7 +29,7 @@ use std::ptr;
 pub use super::glue::{LUA_VERSION_MAJOR, LUA_VERSION_MINOR, LUA_VERSION_NUM, LUA_VERSION_RELEASE};
 pub use super::glue::{LUA_VERSION, LUA_RELEASE, LUA_COPYRIGHT, LUA_AUTHORS};
 
-// LUA_SIGNATURE?
+pub const LUA_SIGNATURE: &'static [u8] = b"\x1bLua";
 
 // option for multiple returns in 'lua_pcall' and 'lua_call'
 pub const LUA_MULTRET: c_int = -1;
@@ -76,10 +76,10 @@ pub const LUA_RIDX_MAINTHREAD: lua_Integer = 1;
 pub const LUA_RIDX_GLOBALS: lua_Integer = 2;
 pub const LUA_RIDX_LAST: lua_Integer = LUA_RIDX_GLOBALS;
 
-// type of numbers in lua
+/// A Lua number, usually equivalent to `f64`.
 pub type lua_Number = luaconf::LUA_NUMBER;
 
-// type for integer functions
+/// A Lua integer, usually equivalent to `i64`.
 pub type lua_Integer = luaconf::LUA_INTEGER;
 
 // unsigned integer type
@@ -88,7 +88,7 @@ pub type lua_Unsigned = luaconf::LUA_UNSIGNED;
 // type for continuation-function contexts
 pub type lua_KContext = luaconf::LUA_KCONTEXT;
 
-// Type for C functions registered with Lua
+/// Type for native functions that can be passed to Lua.
 pub type lua_CFunction = Option<unsafe extern "C" fn(L: *mut lua_State) -> c_int>;
 
 // Type for continuation functions
@@ -98,7 +98,7 @@ pub type lua_KFunction = Option<unsafe extern "C" fn(L: *mut lua_State, status: 
 pub type lua_Reader = Option<unsafe extern "C" fn(L: *mut lua_State, ud: *mut c_void, sz: *mut size_t) -> *const c_char>;
 pub type lua_Writer = Option<unsafe extern "C" fn(L: *mut lua_State, p: *const c_void, sz: size_t, ud: *mut c_void) -> c_int>;
 
-// Type for memory-allocation functions
+/// Type for memory-allocation functions.
 pub type lua_Alloc = Option<unsafe extern "C" fn(ud: *mut c_void, ptr: *mut c_void, osize: size_t, nsize: size_t) -> *mut c_void>;
 
 extern {
@@ -400,7 +400,7 @@ pub const LUA_MASKRET: c_int = 1 << (LUA_HOOKRET as usize);
 pub const LUA_MASKLINE: c_int = 1 << (LUA_HOOKLINE as usize);
 pub const LUA_MASKCOUNT: c_int = 1 << (LUA_HOOKCOUNT as usize);
 
-// Functions to be called by the debugger in specific events
+/// Type for functions to be called on debug events.
 pub type lua_Hook = Option<extern "C" fn(L: *mut lua_State, ar: *mut lua_Debug)>;
 
 extern {

--- a/src/ffi/luaconf.rs
+++ b/src/ffi/luaconf.rs
@@ -36,11 +36,10 @@ pub use super::glue::LUAI_FIRSTPSEUDOIDX;
 
 pub use super::glue::LUA_KCONTEXT;
 
-use super::lua::{lua_Number, lua_Integer};
 use libc::c_int;
 
 #[inline(always)]
-pub unsafe fn lua_numtointeger(n: lua_Number, p: *mut lua_Integer) -> c_int {
+pub unsafe fn lua_numtointeger(n: LUA_NUMBER, p: *mut LUA_INTEGER) -> c_int {
   if n >= (LUA_MININTEGER as LUA_NUMBER) && n < -(LUA_MININTEGER as LUA_NUMBER) {
     *p = n as LUA_INTEGER;
     1

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -22,8 +22,7 @@
 
 //! Low level bindings to Lua.
 
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
 
 // This is more or less in the order it appears in the Lua manual, with the
 // exception of constants, which appear scattered throughout the manual text.
@@ -294,8 +293,8 @@ pub use self::lualib::{
 };
 
 mod glue;
-pub mod luaconf;
-pub mod lua;
-pub mod lauxlib;
-pub mod lualib;
+mod luaconf;
+mod lua;
+mod lauxlib;
+mod lualib;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,6 @@ extern crate bitflags;
 pub use wrapper::state::{
   State,
 
-  Number,
-  Integer,
-  Function,
-  Allocator,
-  Hook,
-  Index,
-
   Arithmetic,
   Comparison,
   ThreadStatus,
@@ -53,5 +46,19 @@ pub use wrapper::state::{
   RIDX_MAINTHREAD, RIDX_GLOBALS
 };
 
+pub use wrapper::convert::{
+  ToLua,
+  FromLua
+};
+
+pub use ffi::lua_Number as Number;
+pub use ffi::lua_Integer as Integer;
+pub use ffi::lua_CFunction as Function;
+pub use ffi::lua_Alloc as Allocator;
+pub use ffi::lua_Hook as Hook;
+
+/// Integer type used to index the Lua stack, usually `i32`.
+pub type Index = libc::c_int;
+
 pub mod ffi;
-pub mod wrapper;
+mod wrapper;

--- a/src/wrapper/convert.rs
+++ b/src/wrapper/convert.rs
@@ -22,7 +22,7 @@
 
 //! Implements conversions for Rust types to and from Lua.
 
-use super::state::{State, Integer, Number, Function};
+use ::{State, Integer, Number, Function};
 
 /// Trait for types that can be pushed onto the stack of a Lua state.
 ///


### PR DESCRIPTION
This patch has the goal of improving the appearance of the docs:
* Add missing documentation text and tweak some other text.
* Remove `pub` from modules whose members are all re-exported anyways.
* Change some type aliases to re-exports so that their docs are clearer.