### PR TITLE
Add lua_func! macro to wrap safe functions as FFI functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,6 @@ pub type Index = libc::c_int;
 
 pub mod ffi;
 mod wrapper;
+
+#[doc(hidden)]
+pub mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,29 @@
+use std::mem;
+
+use libc::c_int;
+
+use State;
+use ffi::{lua_State, lua_CFunction};
+
+/// Wrap a `fn(&mut State) -> u32` as an ffi-suitable `Function`. The argument
+/// must be a path, so that the specific `fn` is known at compile-time.
+#[macro_export]
+macro_rules! lua_func {
+  ($func:path) => { $crate::macros::_wrap(|s| $crate::macros::_check_type($func)(s)) }
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn _check_type(f: fn(&mut State) -> c_int) -> fn(&mut State) -> c_int {
+  f
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn _wrap<F: Fn(&mut State) -> c_int>(_: F) -> lua_CFunction {
+  unsafe extern fn wrapped<F: Fn(&mut State) -> c_int>(s: *mut lua_State) -> c_int {
+    mem::transmute::<&(), &F>(&())(&mut State::from_ptr(s))
+  }
+  assert!(mem::size_of::<F>() == 0, "can only wrap zero-sized closures");
+  Some(wrapped::<F>)
+}


### PR DESCRIPTION
This would be used like:
```rust
fn tostring(lua: &mut State) -> i32 {
	lua.check_any(1);
	lua.to_str(1);
	1
}

// other fns...

fn load_base_lib(lua: &mut State) {
	lua.push_global_table();
	lua.set_fns(&[
		("tostring", lua_func!(tostring)),
		// other fns...
	]);
	lua.pop(1);
}
```

Essentially, the burden of declaring the `unsafe extern "C" fn` and calling `State::from_ptr` is moved to the library, and clients can just declare `fn(&mut State) -> i32` without needing `unsafe` at all.

My investigations did not yield a way to provide this functionality except through a macro; I've tried to make it as ergonomic and safe as possible.