### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/Cargo.lock
+/target/
+/src/ffi/glue.rs


### PR DESCRIPTION
This ignores the `Cargo.lock` file and `target` directory as recommended by Cargo, as well as the `src/ffi/glue.rs` file generated by the build script, so they do not pollute `git status` when working within the repo.