### PR TITLE
Configurable index for FromLua

### DIFF
--- a/src/wrapper/convert.rs
+++ b/src/wrapper/convert.rs
@@ -22,7 +22,7 @@
 
 //! Implements conversions for Rust types to and from Lua.
 
-use ::{State, Integer, Number, Function};
+use ::{State, Integer, Number, Function, Index};
 
 /// Trait for types that can be pushed onto the stack of a Lua state.
 ///
@@ -93,19 +93,19 @@ impl<T: ToLua> ToLua for Option<T> {
 pub trait FromLua: Sized {
   /// Converts the value on top of the stack of a Lua state to a value of type
   /// `Option<Self>`.
-  fn from_lua(state: &mut State) -> Option<Self>;
+  fn from_lua(state: &mut State, index: Index) -> Option<Self>;
 }
 
 impl FromLua for String {
-  fn from_lua(state: &mut State) -> Option<String> {
-    state.to_str(-1).map(ToOwned::to_owned)
+  fn from_lua(state: &mut State, index: Index) -> Option<String> {
+    state.to_str(index).map(ToOwned::to_owned)
   }
 }
 
 impl FromLua for Integer {
-  fn from_lua(state: &mut State) -> Option<Integer> {
-    if state.is_integer(-1) {
-      Some(state.to_integer(-1))
+  fn from_lua(state: &mut State, index: Index) -> Option<Integer> {
+    if state.is_integer(index) {
+      Some(state.to_integer(index))
     } else {
       None
     }
@@ -113,9 +113,9 @@ impl FromLua for Integer {
 }
 
 impl FromLua for Number {
-  fn from_lua(state: &mut State) -> Option<Number> {
-    if state.is_number(-1) {
-      Some(state.to_number(-1))
+  fn from_lua(state: &mut State, index: Index) -> Option<Number> {
+    if state.is_number(index) {
+      Some(state.to_number(index))
     } else {
       None
     }
@@ -123,9 +123,9 @@ impl FromLua for Number {
 }
 
 impl FromLua for bool {
-  fn from_lua(state: &mut State) -> Option<bool> {
-    if state.is_bool(-1) {
-      Some(state.to_bool(-1))
+  fn from_lua(state: &mut State, index: Index) -> Option<bool> {
+    if state.is_bool(index) {
+      Some(state.to_bool(index))
     } else {
       None
     }
@@ -134,9 +134,9 @@ impl FromLua for bool {
 
 //#[unstable(reason="this is an experimental trait")]
 impl FromLua for Function {
-  fn from_lua(state: &mut State) -> Option<Function> {
-    if state.is_native_fn(-1) {
-      Some(state.to_native_fn(-1))
+  fn from_lua(state: &mut State, index: Index) -> Option<Function> {
+    if state.is_native_fn(index) {
+      Some(state.to_native_fn(index))
     } else {
       None
     }

--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -336,8 +336,8 @@ impl State {
 
   /// Converts the value on top of the stack to a value of type `T` and returns
   /// it.
-  pub fn to_type<T: FromLua>(&mut self) -> Option<T> {
-    FromLua::from_lua(self)
+  pub fn to_type<T: FromLua>(&mut self, index: Index) -> Option<T> {
+    FromLua::from_lua(self, index)
   }
 
   //===========================================================================


### PR DESCRIPTION
Makes the index used for `FromLua` configurable, so that `State::to_type()` can be used on any value on the Lua stack. Fixes #27.