### PR TITLE
Improve buildscript for cross-compilation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT"
 build = "build.rs"
 links = "lua"
 
+[build-dependencies]
+gcc = "0.3"
+
 [dependencies]
 bitflags = "0.1"
 libc = "^0.1.10"


### PR DESCRIPTION
See #29 for important discussion.

The support is still not perfect, because `glue` is still compiled for the host platform and some of the types it produces may not match the target platform, but cross-compilation should at least be possible now.

I tested that the following configurations worked:
* Host `x86_64-pc-windows-gnu`, target same
* Host `x86_64-pc-windows-gnu`, target `i686-pc-windows-gnu`
* Host `x86_64-unknown-linux-gnu`, target same
* Host `x86_64-unknown-linux-gnu`, target `x86_64-pc-windows-gnu`