### PR TITLE
Add `State.load_library` and `State.preload_library` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use wrapper::state::{
   ThreadStatus,
   GcOption,
   Type,
+  Library,
 
   Reference,
   REFNIL, NOREF,


### PR DESCRIPTION
`load_library` is a correct way to load a built-in library, that exposes
the library to the lua code.

`preload_library` puts the built-in library to the `_PRELOAD` table so
lua code can `require` the module (whithout putting it into the globals)

Current `open_xxx` methods (except `open_libs`) are cumbersome to use. Since they just load a module and put it on stack. So you need to remember to store it into an appropriate name in the globals and pop it from stack. I believe that `open_xxx` methods should be deprecated.

The proper way to load modules (and the one used in this pull request) is here: http://www.lua.org/source/5.3/linit.c.html