### PR TITLE
Add method to create a state with Rust's allocator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,13 @@
 
 #![crate_name = "lua"]
 #![crate_type = "lib"]
+#![feature(alloc, heap_api, test)]
 
+extern crate alloc;
 extern crate libc;
 #[macro_use]
 extern crate bitflags;
+extern crate test;
 
 pub use wrapper::state::{
   State,
@@ -69,3 +72,7 @@ mod wrapper;
 
 #[doc(hidden)]
 pub mod macros;
+
+
+#[cfg(test)]
+mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,27 @@
+use super::*;
+use test::Bencher;
+
+const CODE: &'static str = "\
+  local array = {}
+  local array2 = {}
+  for x = 1, 1000 do
+    table.insert(array, x)
+    table.insert(array2, x)
+  end
+  array = nil
+  arary2 = nil
+";
+
+#[bench]
+fn bench_system(b: &mut Bencher) {
+    let mut state = State::new();
+    state.open_libs();
+    b.iter(|| state.do_string(CODE));
+}
+
+#[bench]
+fn bench_native(b: &mut Bencher) {
+    let mut state = State::new_native();
+    state.open_libs();
+    b.iter(|| state.do_string(CODE));
+}


### PR DESCRIPTION
This PR intended for #48 (now it's quick & dirty)

Benchmark results:
```
running 2 tests
test tests::bench_native ... bench:   1,172,638 ns/iter (+/- 540,124)
test tests::bench_system ... bench:   1,176,564 ns/iter (+/- 500,759)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured
```
Results are similar for Windows. Often system is little faster. I think for windows malloc uses in both cases, but with Rust's allocator version my wrapper adds little overhead.

For Linux I take segfault:
```
test tests::bench_native ... error: Process didn't exit successfully: `/home/denis/workspace/github.com/lua-alloc/target/release/lua-fbedb8876967943b --bench` (signal: 11, SIGSEGV: invalid memory reference)
```

I think there is a difference in Rust's wrappers behaviour for different systems. But why?!

And what about align? I don't know how to detect right value for lua requirements.