### PR TITLE
Use Rust allocator (jemalloc) rather than system allocator

### DIFF
--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -269,6 +269,50 @@ unsafe extern fn continue_func<F>(st: *mut lua_State, status: c_int, ctx: ffi::l
 /// Box for extra data.
 pub type Extra = Box<any::Any + 'static + Send>;
 
+unsafe extern fn alloc_func(_: *mut c_void, ptr: *mut c_void, old_size: size_t, new_size: size_t) -> *mut c_void {
+  // In GCC and MSVC, malloc uses an alignment calculated roughly by:
+  //   max(2 * sizeof(size_t), alignof(long double))
+  // The stable high-level API used here does not expose alignment directly, so
+  // we get as close as possible by using usize to determine alignment. Lua
+  // seems unlikely to require 16-byte alignment for any of its purposes.
+
+  #[inline]
+  fn divide_size(size: size_t) -> usize {
+    1 + (size - 1) / mem::size_of::<usize>()
+  }
+
+  let ptr = ptr as *mut usize;
+  if new_size == 0 {
+    // if new_size is 0, act like free()
+    if !ptr.is_null() {
+      // Lua promises to provide the correct old_size
+      drop(Vec::<usize>::from_raw_parts(ptr, 0, divide_size(old_size)));
+    }
+    ptr::null_mut()
+  } else {
+    // otherwise, act like realloc()
+    let mut vec;
+    if ptr.is_null() {
+      // old_size is a type indicator, not used here
+      vec = Vec::<usize>::with_capacity(divide_size(new_size));
+    } else {
+      // Lua promises to provide the correct old_size
+      if new_size > old_size {
+        // resulting capacity should be new_size
+        vec = Vec::<usize>::from_raw_parts(ptr, 0, divide_size(old_size));
+        vec.reserve_exact(divide_size(new_size));
+      } else {
+        // Lua assumes this will never fail
+        vec = Vec::<usize>::from_raw_parts(ptr, divide_size(new_size), divide_size(old_size));
+        vec.shrink_to_fit();
+      }
+    }
+    let res = vec.as_mut_ptr();
+    mem::forget(vec); // don't deallocate
+    res as *mut c_void
+  }
+}
+
 /// An idiomatic, Rust wrapper around `lua_State`.
 ///
 /// Function names adhere to Rust naming conventions. Most of the time, this
@@ -291,10 +335,11 @@ unsafe impl Send for State {}
 
 impl State {
   /// Initializes a new Lua state. This function does not open any libraries
-  /// by default. Calls `luaL_newstate` internally.
+  /// by default. Calls `lua_newstate` internally.
   pub fn new() -> State {
     unsafe {
-      let mut state = State { L: ffi::luaL_newstate(), owned: true };
+      let state = ffi::lua_newstate(Some(alloc_func), ptr::null_mut());
+      let mut state = State { L: state, owned: true };
       state.reset_extra();
       state
     }


### PR DESCRIPTION
Stable PR for #48. Benchmarks not included here, but much like #52 there is not really a measurable difference in speed due to the change.

In the name of simplicity, the current implementation returns allocations with the same alignment as `usize` (4 or 8 bytes). According to my research, GCC and MSVC's mallocs both return allocations with an alignment double that, but it would require 16 bytes of overhead per allocation and additional bookkeeping I have not yet implemented to be able to satisfy this alignment. I don't know of any standard C type that actually requires 16-byte alignment.