### PR TITLE
Re-export libc types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 #![crate_name = "lua"]
 #![crate_type = "lib"]
 
-extern crate libc;
+pub extern crate libc;
 #[macro_use]
 extern crate bitflags;
 


### PR DESCRIPTION
This library forces to use `libc` crate explicitly.

I have to use both `libc` and `lua` anytime, but I, really, need one everytime.