### PR TITLE
Use Mutex to protect Extra

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate bitflags;
 
 pub use wrapper::state::{
   State,
+  Extra,
 
   Arithmetic,
   Comparison,

--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -26,6 +26,8 @@ use ffi::{lua_State, lua_Debug};
 use libc::{c_int, c_void, c_char, size_t};
 use std::{mem, ptr, str, slice, any};
 use std::ffi::{CString, CStr};
+use std::ops::DerefMut;
+use std::sync::Mutex;
 use super::convert::{ToLua, FromLua};
 
 use ::{
@@ -268,6 +270,7 @@ unsafe extern fn continue_func<F>(st: *mut lua_State, status: c_int, ctx: ffi::l
 
 /// Box for extra data.
 pub type Extra = Box<any::Any + 'static + Send>;
+type ExtraHolder = *mut *mut Mutex<Option<Extra>>;
 
 unsafe extern fn alloc_func(_: *mut c_void, ptr: *mut c_void, old_size: size_t, new_size: size_t) -> *mut c_void {
   // In GCC and MSVC, malloc uses an alignment calculated roughly by:
@@ -339,9 +342,10 @@ impl State {
   pub fn new() -> State {
     unsafe {
       let state = ffi::lua_newstate(Some(alloc_func), ptr::null_mut());
-      let mut state = State { L: state, owned: true };
-      state.reset_extra();
-      state
+      let extra_ptr = ffi::lua_getextraspace(state) as ExtraHolder;
+      let mutex = Box::new(Mutex::new(None));
+      *extra_ptr = Box::into_raw(mutex);
+      State { L: state, owned: true }
     }
   }
 
@@ -477,9 +481,7 @@ impl State {
   /// Maps to `lua_newthread`.
   pub fn new_thread(&mut self) -> State {
     unsafe {
-      let mut state = State::from_ptr(ffi::lua_newthread(self.L));
-      state.reset_extra();
-      state
+      State::from_ptr(ffi::lua_newthread(self.L))
     }
   }
 
@@ -1037,40 +1039,39 @@ impl State {
   // Some useful macros (here implemented as functions)
   //===========================================================================
 
-  #[inline]
-  unsafe fn reset_extra(&mut self) {
-    let space_ptr = ffi::lua_getextraspace(self.L) as *mut *mut Extra;
-    *space_ptr = ptr::null_mut();
-  }
-
   /// Set extra data. Return previous value if it was set.
   pub fn set_extra(&mut self, extra: Option<Extra>) -> Option<Extra> {
+    self.with_extra(|opt_extra| mem::replace(opt_extra, extra))
+  }
+
+  /// Do some actions with mutable extra.
+  pub fn with_extra<F, R>(&mut self, closure: F) -> R
+    where F: FnOnce(&mut Option<Extra>) -> R {
     unsafe {
-      let space_ptr = ffi::lua_getextraspace(self.L) as *mut *mut Extra;
-      let new_value = match extra {
-        Some(extra) => Box::into_raw(Box::new(extra)),
-        None => ptr::null_mut(),
+      let extra_ptr = ffi::lua_getextraspace(self.L) as ExtraHolder;
+      let mutex = Box::from_raw(*extra_ptr);
+      let result = {
+        let mut guard = mutex.lock().unwrap();
+        closure(guard.deref_mut())
       };
-      let old_value = ptr::replace(space_ptr, new_value);
-      if old_value.is_null() {
-        None
-      } else {
-        Some(*Box::from_raw(old_value))
-      }
+      mem::forget(mutex);
+      result
     }
   }
 
-  /// Get the currently set extra data, if any.
-  pub fn get_extra(&mut self) -> Option<&mut (any::Any + 'static + Send)> {
-    unsafe {
-      let space_ptr = ffi::lua_getextraspace(self.L) as *mut *mut Extra;
-      let box_ptr = *space_ptr;
-      if box_ptr.is_null() {
-        None
-      } else {
-        Some(&mut **box_ptr)
-      }
-    }
+  /// Unwrap and downcast extra to typed.
+  ///
+  /// # Panics
+  ///
+  /// Panics if state has no attached `Extra` or it's impossible to downcast to `T`.
+  ///
+  pub fn with_extra_typed<T, F, R>(&mut self, closure: F) -> R
+    where T: any::Any, F: FnOnce(&mut T) -> R {
+    self.with_extra(|extra| {
+      let data = extra.as_mut().unwrap()
+        .downcast_mut::<T>().unwrap();
+      closure(data)
+    })
   }
 
   /// Maps to `lua_tonumber`.
@@ -1624,8 +1625,11 @@ impl State {
 impl Drop for State {
   fn drop(&mut self) {
     if self.owned {
-      let _ = self.set_extra(None);
-      unsafe { ffi::lua_close(self.L) }
+      unsafe {
+        let extra_ptr = ffi::lua_getextraspace(self.L) as ExtraHolder;
+        ptr::drop_in_place(*extra_ptr);
+        ffi::lua_close(self.L);
+      }
     }
   }
 }

--- a/tests/extra.rs
+++ b/tests/extra.rs
@@ -1,57 +1,77 @@
 extern crate lua;
 
-struct ExtraData {
-    value: String,
-}
-
-fn check(state: &mut lua::State) {
-    let extra = ExtraData {
-      value: "Initial data".to_string(),
-    };
-
-    assert!(state.get_extra().is_none());
-    assert!(state.set_extra(None).is_none());
-
-    state.set_extra(Some(Box::new(extra)));
-
-    for x in 0..10 {
-        let extra = state.get_extra()
-            .and_then(|a| a.downcast_mut::<ExtraData>()).unwrap();
-        extra.value = format!("Changed to {}", x);
-    }
-
-    {
-        let extra = state.set_extra(None).unwrap();
-        let extra = extra.downcast::<ExtraData>().unwrap();
-        assert_eq!(extra.value, "Changed to 9");
-    }
-
-    assert!(state.get_extra().is_none());
-    assert!(state.set_extra(None).is_none());
+#[derive(PartialEq)]
+struct Data {
+  value: String,
 }
 
 #[test]
 fn test_extra_owned() {
-    let mut state = lua::State::new();
-    check(&mut state);
+  let mut state = lua::State::new();
+
+  let data = Data {
+    value: "Initial data".to_owned(),
+  };
+  state.set_extra(Some(Box::new(data)));
+
+  for x in 0..10 {
+    state.with_extra(|extra| {
+      let data = extra.as_mut().unwrap()
+        .downcast_mut::<Data>().unwrap();
+      data.value = format!("Changed to {}", x);
+    });
+  }
+
+  let extra = state.set_extra(None);
+  let data = extra.as_ref().unwrap()
+    .downcast_ref::<Data>().unwrap();
+  assert_eq!(data.value, "Changed to 9");
 }
 
 #[test]
-fn test_extra_thread() {
-    let mut state = lua::State::new();
-    let extra = ExtraData {
-      value: "Won't be shared!".to_string(),
-    };
-    state.set_extra(Some(Box::new(extra)));
+fn test_extra_typed() {
+  let mut state = lua::State::new();
 
-    let mut thread = state.new_thread();
-    check(&mut thread);
+  let data = Data {
+    value: "Initial data".to_owned(),
+  };
+  state.set_extra(Some(Box::new(data)));
+
+  state.with_extra_typed(|data: &mut Data| {
+    data.value = format!("Use typed");
+  });
+
+  let extra = state.set_extra(None).unwrap();
+  let data = extra.downcast::<Data>().unwrap();
+  assert_eq!(data.value, "Use typed");
 }
 
 #[test]
-fn test_extra_no_impact() {
-    let mut state = lua::State::new();
-    let mut thread = state.new_thread();
-    check(&mut thread);
-    assert!(state.get_extra().is_none());
+fn test_extra_threads() {
+  let mut state = lua::State::new();
+
+  let data = Data {
+    value: "Initial data".to_owned(),
+  };
+  state.set_extra(Some(Box::new(data)));
+
+  let mut thread = state.new_thread();
+  let value = thread.with_extra(|extra| {
+    let data = extra.as_ref().unwrap()
+      .downcast_ref::<Data>().unwrap();
+    data.value.clone()
+  });
+  assert_eq!(value, "Initial data");
+
+  let data = Data {
+    value: "Thread data".to_owned(),
+  };
+  thread.set_extra(Some(Box::new(data)));
+
+  let value = state.with_extra(|extra| {
+    let data = extra.as_ref().unwrap()
+      .downcast_ref::<Data>().unwrap();
+    data.value.clone()
+  });
+  assert_eq!(value, "Thread data");
 }


### PR DESCRIPTION
**This is IMPORTANT PR to prevent memory leaks or other dangerous consequences of using `extra` space.**

This PR improves extra space behavior with **nice backward compatibility**. Previous implementation has some imperfections:
1) Lua never call `drop` than `Extra` data lost in heap and memory leaks
2) We have to wrap `Extra` with `Mutex` explicitly everywhere
Every `Extra` have to implement `Send` because Lua does it. To use `Extra` we have to use `Mutex` explicitly everywhere. This makes code dirty with a lot of explicit mutex locking.

This PR store extra under `Mutex`. Profits:
1) It's safe to use it with Lua's threads (which takes copy of extra pointer by default)
2) This API makes user's code tidy and simpler (look for tests)
3) Works much faster than precise manual mutex control

P.S. Also I've tried to use `Weak` pointers, but it's impossible, because every `Arc` or `Weak` keeps shared `ArcInner` which never frees by Lua and memory leaks. (Example: https://github.com/DenisKolodin/rust-lua53/tree/weak-extra)

