### PR TITLE
Adjust the lifetimes for the lua_load callback

### DIFF
--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -911,11 +911,11 @@ impl State {
 
   // TODO: mode typing?
   /// Maps to `lua_load`.
-  pub fn load<F>(&mut self, mut reader: F, source: &str, mode: &str) -> ThreadStatus
-    where F: FnMut(&mut State) -> &[u8]
+  pub fn load<'l, F>(&'l mut self, mut reader: F, source: &str, mode: &str) -> ThreadStatus
+    where F: FnMut(&mut State) -> &'l [u8]
   {
-    unsafe extern fn read<F>(st: *mut lua_State, ud: *mut c_void, sz: *mut size_t) -> *const c_char
-      where F: FnMut(&mut State) -> &[u8]
+    unsafe extern fn read<'l, F>(st: *mut lua_State, ud: *mut c_void, sz: *mut size_t) -> *const c_char
+      where F: FnMut(&mut State) -> &'l [u8]
     {
       let mut state = State::from_ptr(st);
       let slice = mem::transmute::<_, &mut F>(ud)(&mut state);


### PR DESCRIPTION
Add a lifetime parameter to lua_load, and use it to tie the lifetime of the `&[u8]` returned by the reader function/closure to the borrow lifetime of the Lua state (so the call to `lua_load`).

Note that I'm not completely sure this is correct, but it has solved my case where I really just wanted a version of `load_string` with the `chunkname` option added.  Feel free to reject if I'm just using it wrongly.

I call it a bit like this:

```rust
let mut done = false;
let code = code;  // &str
let empty = &b""[..];
let status = self.state.load(
    |_| {
        if done {
            empty
        } else {
            done = true;
            code.as_bytes()
        }
    },
    source.into().unwrap_or("<string>"),
    "bt");
```   

With the existing lifetimes, the reader callback is:

```rust
FnMut(&mut State) -> &[u8]
```

which I think effectively means that the return value has to be derived from the `State`, ie stored as a Lua value.  I was getting "cannot infer an appropriate lifetime due to conflicting requirements" errors.

I'm not sure how well this works with a re-used buffer (e.g. loading chunks from a file), though.