### PR TITLE
Use reference to convert object to lua

### DIFF
--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -459,7 +459,7 @@ impl State {
   }
 
   /// Pushes the given value onto the stack.
-  pub fn push<T: ToLua>(&mut self, value: T) {
+  pub fn push<T: ToLua>(&mut self, value: &T) {
     value.to_lua(self);
   }
 


### PR DESCRIPTION
Current push declaration is:
```rust
impl State {
    fn push<T: ToLua>(&mut self, value: T)
}
```
But `ToLua` satisfied with the reference `&self` (it doesn't need to own the instance).
```rust
trait ToLua {
    fn to_lua(&self, state: &mut State)
}
```
I don't see any reason to owned value inside push.
But owning makes hard to push **nested** structs with this generic `push` method, because we have convert nested items to owned (clone) to satisfy `push` declaration.

This PR makes tiny backward-incompatible change and uses reference only to push objects ToLua.
```rust
impl State {
    fn push<T: ToLua>(&mut self, value: &T)
}
```