### PR TITLE
fix deprecated `gcc::Config`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -133,7 +133,7 @@ fn prebuild() -> io::Result<()> {
         }
     };
     let build_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let mut config = gcc::Config::new();
+    let mut config = gcc::Build::new();
     let msvc = env::var("TARGET").unwrap().split('-').last().unwrap() == "msvc";
     println!("cargo:rustc-link-lib=static=lua");
     if !msvc && lua_dir.join("liblua.a").exists() {
@@ -154,7 +154,7 @@ fn prebuild() -> io::Result<()> {
         }
         println!("cargo:rustc-link-search=native={}", &build_dir.display());
     }
-    
+
     // Ensure the presence of glue.rs
     if !build_dir.join("glue.rs").exists() {
         // Compile and run glue.c


### PR DESCRIPTION
build with `rustc v1.20.0` will show the following warning:

```
$ cargo build
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling gcc v0.3.54
   Compiling bitflags v0.1.1
   Compiling libc v0.2.32
   Compiling lua v0.0.11 (file:///Users/poga/projects/spacer-workspace/rust-lua53)
warning: use of deprecated item: gcc::Config has been renamed to gcc::Build
   --> build.rs:136:22
    |
136 |     let mut config = gcc::Config::new();
    |                      ^^^^^^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 11.25 secs
```

`gcc::Config` has been renamed to `gcc::Build`.

