### PR TITLE
Infer correct type, it is different on arm.

### DIFF
--- a/src/wrapper/state.rs
+++ b/src/wrapper/state.rs
@@ -702,7 +702,7 @@ impl State {
 
   /// Maps to `lua_pushlstring`.
   pub fn push_bytes(&mut self, s: &[u8]) {
-    unsafe { ffi::lua_pushlstring(self.L, s.as_ptr() as *const i8, s.len() as size_t) };
+    unsafe { ffi::lua_pushlstring(self.L, s.as_ptr() as *const _, s.len() as size_t) };
   }
 
   // omitted: lua_pushvfstring


### PR DESCRIPTION
This fixes a compile type error on arm, where `u8` is expected in this place.