### PR TITLE
Export include path in build metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lua"
-version = "0.0.11"
+version = "0.0.12"
 authors = ["J.C. Moyer"]
 description = "Bindings to Lua 5.3"
 documentation = "https://docs.rs/lua"

--- a/build.rs
+++ b/build.rs
@@ -136,6 +136,7 @@ fn prebuild() -> io::Result<()> {
     let mut config = gcc::Build::new();
     let msvc = env::var("TARGET").unwrap().split('-').last().unwrap() == "msvc";
     println!("cargo:rustc-link-lib=static=lua");
+    println!("cargo:include={}", lua_dir.display());
     if !msvc && lua_dir.join("liblua.a").exists() {
         // If liblua.a is already in lua_dir, use it
         println!("cargo:rustc-link-search=native={}", &lua_dir.display());


### PR DESCRIPTION
This patch uses [build metadata][] to export the directory containing the include files for the copy of Lua that is built.  This allows downstream crates that use the Lua C API to use the same include files that are used to build Lua itself in this crate, by reading from the `DEP_LUA_INCLUDE` environment variable.

[build metadata]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key